### PR TITLE
MSVC, imgui master branch, and sol::state_view support

### DIFF
--- a/sol_ImGui.h
+++ b/sol_ImGui.h
@@ -233,7 +233,7 @@ namespace sol_ImGui
 	inline bool SmallButton(const std::string& label)													{ return ImGui::SmallButton(label.c_str()); }
 	inline bool InvisibleButton(const std::string& stringID, float sizeX, float sizeY)					{ return ImGui::InvisibleButton(stringID.c_str(), { sizeX, sizeY }); }
 	inline bool ArrowButton(const std::string& stringID, int dir)										{ return ImGui::ArrowButton(stringID.c_str(), static_cast<ImGuiDir>(dir)); }
-	inline void Image()																					{ /* TODO: Image(...) ==> UNSUPPORTED */ }
+	inline void Image(void* textureID, float width, float height)										{ ImGui::Image(textureID, ImVec2(width, height)); }
 	//inline void ImageButton()																			{ /* TODO: ImageButton(...) ==> UNSUPPORTED */ }
 	inline std::tuple<bool, bool> Checkbox(const std::string& label, bool v)
 	{
@@ -2819,6 +2819,10 @@ namespace sol_ImGui
 																sol::resolve<void(float, float, float, const std::string&)>(ProgressBar)
 															));
 		ImGui.set_function("Bullet"							, Bullet);
+		ImGui.set_function("Image"							, sol::overload(
+																sol::resolve<void(void*, float, float)>(Image),
+																sol::resolve<void(void*, const ImVec2&, const ImVec2&, const ImVec2&, const ImVec4&, const ImVec4&)>(ImGui::Image) // Original ImGui::Image
+															));
 #pragma endregion Widgets: Main
 		
 #pragma region Widgets: Combo Box


### PR DESCRIPTION
Added ifdef __clang__ around clang pragmas so it can compile in msvc. Added ifndef IMGUI_NO_DOCKING blocks around docking so the bindings can be compatible with imgui master branch as long as IMGUI_NO_DOCKING is defined somewhere. Refactored Init and InitEnum to take either a sol::state or a sol::state_view so that those integrating sol with existing code can also use the bindings.